### PR TITLE
ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider errors

### DIFF
--- a/RefactoringEssentials/CSharp/CodeRefactorings/Custom/ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider.cs
+++ b/RefactoringEssentials/CSharp/CodeRefactorings/Custom/ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider.cs
@@ -27,33 +27,75 @@ namespace RefactoringEssentials.CSharp.CodeRefactorings
             var root = await model.SyntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
             var token = root.FindToken(span.Start);
 
-            var node = token.Parent as AssignmentExpressionSyntax;
-            if (node == null || !node.OperatorToken.Span.Contains(span))
-                return;
+			if (!(token.Parent is AssignmentExpressionSyntax node) || !node.OperatorToken.Span.Contains(span))
+				return;
 
-            var updatedNode = ReplaceWithOperatorAssignmentCodeRefactoringProvider.CreateAssignment(node) ?? node;
+			if (!TryCheckIncrementOrDecrement(node, out var updatedNode))
+				return;
 
-            if ((!updatedNode.IsKind(SyntaxKind.AddAssignmentExpression) && !updatedNode.IsKind(SyntaxKind.SubtractAssignmentExpression)))
-                return;
+			bool isIncrement = updatedNode.IsKind(SyntaxKind.AddAssignmentExpression);
+			if (!IsIntegralTypeOrHasOperatorOverloaded(model, node.Left, isIncrement) || !IsIntegralTypeOrHasOperatorOverloaded(model, node.Right, isIncrement))
+				return;
 
-            var rightLiteral = updatedNode.Right as LiteralExpressionSyntax;
-            if (rightLiteral == null || ((int)rightLiteral.Token.Value) != 1)
-                return;
+			string description = isIncrement ? GettextCatalog.GetString("To '{0}++'") : GettextCatalog.GetString("To '{0}--'");
 
-            context.RegisterRefactoring(
-                CodeActionFactory.Create(
-                    token.Span,
-                    DiagnosticSeverity.Info,
-                    updatedNode.IsKind(SyntaxKind.AddAssignmentExpression) ? GettextCatalog.GetString("To '{0}++'") : GettextCatalog.GetString("To '{0}--'"),
+			context.RegisterRefactoring(
+				CodeActionFactory.Create(
+					token.Span,
+					DiagnosticSeverity.Info,
+					string.Format (description, node.Left),
                     t2 =>
                     {
-                        var newNode = SyntaxFactory.PostfixUnaryExpression(updatedNode.IsKind(SyntaxKind.AddAssignmentExpression) ? SyntaxKind.PostIncrementExpression : SyntaxKind.PostDecrementExpression, updatedNode.Left);
-                        var newRoot = root.ReplaceNode((SyntaxNode)node, newNode.WithAdditionalAnnotations(Formatter.Annotation).WithLeadingTrivia(node.GetLeadingTrivia()));
+                        var newNode = SyntaxFactory.PostfixUnaryExpression(isIncrement ? SyntaxKind.PostIncrementExpression : SyntaxKind.PostDecrementExpression, updatedNode.Left);
+                        var newRoot = root.ReplaceNode(node, newNode.WithAdditionalAnnotations(Formatter.Annotation).WithLeadingTrivia(node.GetLeadingTrivia()));
                         return Task.FromResult(document.WithSyntaxRoot(newRoot));
                     }
                 )
             );
         }
-    }
+
+		static bool TryCheckIncrementOrDecrement (AssignmentExpressionSyntax node, out AssignmentExpressionSyntax updatedNode)
+		{
+			updatedNode = ReplaceWithOperatorAssignmentCodeRefactoringProvider.CreateAssignment(node) ?? node;
+
+			if ((!updatedNode.IsKind(SyntaxKind.AddAssignmentExpression) && !updatedNode.IsKind(SyntaxKind.SubtractAssignmentExpression)))
+				return false;
+
+			if (!(updatedNode.Right is LiteralExpressionSyntax rightLiteral))
+				return false;
+
+			return rightLiteral.Token.Value is 1;
+		}
+
+		static bool IsIntegralTypeOrHasOperatorOverloaded(SemanticModel model, SyntaxNode node, bool isIncrement)
+		{
+			var type = model.GetTypeInfo(node).Type;
+			if (type == null)
+				return false;
+
+			switch (type.SpecialType)
+			{
+				case SpecialType.System_Byte:
+				case SpecialType.System_Char:
+				case SpecialType.System_Decimal:
+				case SpecialType.System_Double:
+				case SpecialType.System_Int16:
+				case SpecialType.System_Int32:
+				case SpecialType.System_Int64:
+				case SpecialType.System_IntPtr:
+				case SpecialType.System_SByte:
+				case SpecialType.System_Single:
+				case SpecialType.System_UInt16:
+				case SpecialType.System_UInt32:
+				case SpecialType.System_UInt64:
+				case SpecialType.System_UIntPtr:
+					return true;
+			}
+
+			var memberToLookup = isIncrement ? WellKnownMemberNames.IncrementOperatorName : WellKnownMemberNames.DecrementOperatorName;
+			var members = type.GetMembers(memberToLookup);
+			return !members.IsDefaultOrEmpty;
+		}
+	}
 }
 

--- a/Tests/CSharp/CodeRefactorings/ReplaceAssignmentWithPostfixExpressionTests.cs
+++ b/Tests/CSharp/CodeRefactorings/ReplaceAssignmentWithPostfixExpressionTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using RefactoringEssentials.CSharp.CodeRefactorings;
 using Xunit;
 
@@ -85,6 +86,185 @@ class Test
 	{
         i++;
 	}
+}");
+        }
+
+        static readonly List<object[]> integralTypes = new List<object[]>
+        {
+            new object[] { "sbyte" } ,
+            new object[] { "byte" } ,
+            new object[] { "char" } ,
+            new object[] { "short" } ,
+            new object[] { "ushort" } ,
+            new object[] { "int" } ,
+            new object[] { "uint" } ,
+            new object[] { "long" } ,
+            new object[] { "ulong" } ,
+            new object[] { "decimal" } ,
+        };
+
+        public static IEnumerable<object[]> IntegralTypes => integralTypes;
+
+        [Theory]
+        [MemberData(nameof(IntegralTypes))]
+        public void TestIncrement(string type)
+        {
+            string test = @"class TestClass {
+    public void Increment()
+    {
+        " + type + @" x = 0;
+        x $+= 1;
+    }
+}";
+            string result = @"class TestClass {
+    public void Increment()
+    {
+        " + type + @" x = 0;
+        x++;
+    }
+}";
+
+            Test<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(test, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(IntegralTypes))]
+        public void TestDecrement(string type)
+        {
+            string test = @"class TestClass {
+    public void Decrement()
+    {
+        " + type + @" x = 0;
+        x $-= 1;
+    }
+}";
+            string result = @"class TestClass {
+    public void Decrement()
+    {
+        " + type + @" x = 0;
+        x--;
+    }
+}";
+            string a = "asdf";
+            a += 1;
+            a += "1";
+            char c = '0';
+            c++;
+
+            Test<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(test, result);
+        }
+
+        [Fact]
+        public void StringIsNotACandidate()
+        {
+            TestWrongContext<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(@"class TestClass {
+    public void Decrement()
+    {
+        string x = 0;
+        x $+= 1;
+    }
+}");
+        }
+
+        [Fact]
+        public void NoExceptionWhenAddingNonIntegralType()
+        {
+            TestWrongContext<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(@"class TestClass {
+    public void Decrement()
+    {
+        string x = 0;
+        x $+= ""1"";
+    }
+}");
+        }
+
+        [Fact]
+        public void NoRefactoringIfNoOperatorPlusPlusDefined()
+        {
+            TestWrongContext<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(@"class Operand {
+    public static Operand operator +(Operand a, int b)
+    {
+        return new Operand();
+    }
+}
+
+class TestClass {
+    public void Increment()
+    {
+        Operand x = new Operand ();
+        x $+= 1;
+    }
+}");
+        }
+
+        [Fact]
+        public void RefactoringOfferedForOverloadedOperators()
+        {
+            Test<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(@"class Operand {
+    public static Operand operator +(Operand a, int b)
+    {
+        return new Operand();
+    }
+
+    public static Operand operator ++(Operand a)
+    {
+        return new Operand();
+    }
+}
+
+class TestClass {
+    public void Increment()
+    {
+        Operand x = new Operand ();
+        x $+= 1;
+    }
+}", @"class Operand {
+    public static Operand operator +(Operand a, int b)
+    {
+        return new Operand();
+    }
+
+    public static Operand operator ++(Operand a)
+    {
+        return new Operand();
+    }
+}
+
+class TestClass {
+    public void Increment()
+    {
+        Operand x = new Operand ();
+        x++;
+    }
+}");
+        }
+
+        [Fact]
+        public void RefactoringNotOfferedForOverloadedOperatorsNotOne()
+        {
+            TestWrongContext<ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider>(@"class Operand {
+    public static Operand operator +(Operand a, int b)
+    {
+        return new Operand();
+    }
+
+    public static Operand operator +(Operand a, Operand b)
+    {
+        return new Operand();
+    }
+
+    public static Operand operator ++(Operand a)
+    {
+        return new Operand();
+    }
+}
+
+class TestClass {
+    public void Increment()
+    {
+        Operand x = new Operand ();
+        x $+= new Operand();
+    }
 }");
         }
 


### PR DESCRIPTION
When trying to do `+= "str"`, and moving onto the equals sign, the code
refactoring would crash with an invalid cast.

Make the code more reliable, and also don't offer += when there's no
operator++ defined on the type.

Fixes VSTS #723151 - [Feedback] ReplaceAssignmentWithPostfixExpressionCodeRefactoringProvider crashes along with others