### PR TITLE
Fix NRE when querying semantic model

### DIFF
--- a/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/AccessToStaticMemberViaDerivedTypeCodeFixProvider.cs
+++ b/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/AccessToStaticMemberViaDerivedTypeCodeFixProvider.cs
@@ -35,8 +35,11 @@ namespace RefactoringEssentials.CSharp.Diagnostics
             var node = root.FindNode(context.Span);
             if (node == null)
                 return;
-            var typeInfo = semanticModel.GetSymbolInfo(node.Parent);
-            var newType = typeInfo.Symbol.ContainingType.ToMinimalDisplayString(semanticModel, node.SpanStart);
+            var symbol = semanticModel.GetSymbolInfo(node.Parent).Symbol;
+            if (symbol == null)
+                return;
+            
+            var newType = symbol.ContainingType.ToMinimalDisplayString(semanticModel, node.SpanStart);
             var newRoot = root.ReplaceNode((SyntaxNode)node, SyntaxFactory.ParseTypeName(newType).WithLeadingTrivia(node.GetLeadingTrivia()));
             context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, string.Format("Use base qualifier '{0}'", newType), document.WithSyntaxRoot(newRoot)), diagnostic);
         }


### PR DESCRIPTION
```
ERROR [2019-02-03 11:29:59Z]: Roslyn error: Extension_Exception AccessToStaticMemberViaDerivedTypeCodeFixProvider : Object reference not set to an instance of an object
  at RefactoringEssentials.CSharp.Diagnostics.AccessToStaticMemberViaDerivedTypeCodeFixProvider.RegisterCodeFixesAsync (Microsoft.CodeAnalysis.CodeFixes.CodeFixContext context) [0x0011a] in /Users/vsts/agent/2.144.2/work/1/s/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials/CSharp/Diagnostics/Synced/PracticesAndImprovements/AccessToStaticMemberViaDerivedTypeCodeFixProvider.cs:39 
  at Microsoft.CodeAnalysis.CodeFixes.CodeFixService.GetCodeFixesAsync (Microsoft.CodeAnalysis.Document document, Microsoft.CodeAnalysis.Text.TextSpan span, Microsoft.CodeAnalysis.CodeFixes.CodeFixProvider fixer, System.Collections.Immutable.ImmutableArray`1[T] diagnostics, System.Threading.CancellationToken cancellationToken) [0x00094] in /_/src/EditorFeatures/Core/Implementation/CodeFixes/CodeFixService.cs:326 
  at Microsoft.CodeAnalysis.Extensions.IExtensionManagerExtensions.PerformFunctionAsync[T] (Microsoft.CodeAnalysis.Extensions.IExtensionManager extensionManager, System.Object extension, System.Func`1[TResult] function, T defaultValue) [0x00043] in /_/src/Workspaces/Core/Portable/ExtensionManager/IExtensionManagerExtensions.cs:95 
```

Fixes VSTS #785201 - AccessToStaticMemberViaDerivedTypeCodeFixProvider null reference exception